### PR TITLE
Added comments to documentation regarding the control grid scaling in case of using an affine transformation as t0

### DIFF
--- a/dox/manual/manual.tex
+++ b/dox/manual/manual.tex
@@ -1752,6 +1752,12 @@ also possible to specify the grid in voxel units:
 \begin{quote}
 \texttt{(FinalGridSpacingInVoxels 16.0 16.0 16.0)}
 \end{quote}
+
+Note that in the case of providing an affine transformation as initial
+transformation to the B-spline registration, elastix will scale
+the control grid to cover the fixed image domain in the space
+defined by the initial transform.
+
 If the final B-spline grid spacing is chosen high, then you cannot
 match small structures. On the other hand, if the grid spacing is
 chosen very low, then small structures can be matched, but you

--- a/src/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
+++ b/src/Components/Transforms/AdvancedBSplineTransform/elxAdvancedBSplineTransform.h
@@ -53,6 +53,8 @@ namespace elastix
  *    If not specified, the FinalGridSpacingInVoxels is used, or the FinalGridSpacing,
  *    to compute a FinalGridSpacingInPhysicalUnits. If those are not specified, the default
  *    value for FinalGridSpacingInVoxels is used to compute a FinalGridSpacingInPhysicalUnits.
+ *    If an affine transformation is provided as initial transformation, the control grid
+ *    will be scaled to cover the fixed image domain in the space defined by the initial transformation.
  * \parameter GridSpacingSchedule: the grid spacing downsampling factors for the B-spline transform
  *    for each dimension and each resolution. \n
  *    example: <tt>(GridSpacingSchedule 4.0 4.0 2.0 2.0 1.0 1.0)</tt> \n

--- a/src/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
+++ b/src/Components/Transforms/BSplineStackTransform/elxBSplineStackTransform.h
@@ -64,6 +64,8 @@ namespace elastix
  *    If not specified, the FinalGridSpacingInVoxels is used, or the FinalGridSpacing,
  *    to compute a FinalGridSpacingInPhysicalUnits. If those are not specified, the default
  *    value for FinalGridSpacingInVoxels is used to compute a FinalGridSpacingInPhysicalUnits.
+ *    If an affine transformation is provided as initial transformation, the control grid
+ *    will be scaled to cover the fixed image domain in the space defined by the initial transformation.
  * \parameter GridSpacingSchedule: the grid spacing downsampling factors for the B-spline transform
  *    for each dimension and each resolution. \n
  *    example: <tt>(GridSpacingSchedule 4.0 4.0 2.0 2.0 1.0 1.0)</tt> \n

--- a/src/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
+++ b/src/Components/Transforms/MultiBSplineTransformWithNormal/elxMultiBSplineTransformWithNormal.h
@@ -53,6 +53,8 @@ namespace elastix
  *    If not specified, the FinalGridSpacingInVoxels is used, or the FinalGridSpacing,
  *    to compute a FinalGridSpacingInPhysicalUnits. If those are not specified, the default
  *    value for FinalGridSpacingInVoxels is used to compute a FinalGridSpacingInPhysicalUnits.
+ *    If an affine transformation is provided as initial transformation, the control grid
+ *    will be scaled to cover the fixed image domain in the space defined by the initial transformation.
  * \parameter GridSpacingSchedule: the grid spacing downsampling factors for the B-spline transform
  *    for each dimension and each resolution. \n
  *    example: <tt>(GridSpacingSchedule 4.0 4.0 2.0 2.0 1.0 1.0)</tt> \n

--- a/src/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
+++ b/src/Components/Transforms/RecursiveBSplineTransform/elxRecursiveBSplineTransform.h
@@ -53,6 +53,8 @@ namespace elastix
  *    If not specified, the FinalGridSpacingInVoxels is used, or the FinalGridSpacing,
  *    to compute a FinalGridSpacingInPhysicalUnits. If those are not specified, the default
  *    value for FinalGridSpacingInVoxels is used to compute a FinalGridSpacingInPhysicalUnits.
+ *    If an affine transformation is provided as initial transformation, the control grid
+ *    will be scaled to cover the fixed image domain in the space defined by the initial transformation.
  * \parameter GridSpacingSchedule: the grid spacing downsampling factors for the B-spline transform
  *    for each dimension and each resolution. \n
  *    example: <tt>(GridSpacingSchedule 4.0 4.0 2.0 2.0 1.0 1.0)</tt> \n


### PR DESCRIPTION
Added clarifying comments regarding the scaling of the control grid in the case of providing an affine transformation as starting point to: 
- docstrings of transforms MultiBSplineTransformWithNormal, AdvancedBSplineTransform, BSplineStackTransform, RecursiveBSplineTransform 
- the manual (section 5.3.5)

See http://lists.bigr.nl/pipermail/elastix/2017-February/002501.html